### PR TITLE
Introduce more lifetimes

### DIFF
--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -48,7 +48,7 @@ impl<'a> SpellerArchive<'a> {
         // Load transducers
         let acceptor_data = slice_by_name(&mut archive, &slice, &metadata.acceptor.id);
         let errmodel_data = slice_by_name(&mut archive, &slice, &metadata.errmodel.id);
-        
+
         let acceptor = Transducer::from_bytes(&acceptor_data);
         let errmodel = Transducer::from_bytes(&errmodel_data);
 
@@ -61,7 +61,7 @@ impl<'a> SpellerArchive<'a> {
         }
     }
 
-    pub fn speller(&self) -> &Speller<'a> {
+    pub fn speller<'b>(&'b self) -> &'b Speller<'a> where 'a: 'b {
         &self.speller
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,16 @@ fn test_load_zhfst() {
     let two = zhfst.speller();
     let res = two.suggest("sami");
 }
+
+#[test]
+fn run_shit() {
+    use transducer::Transducer;
+    use speller::Speller;
+
+    let data = vec![];
+    let acceptor = Transducer::from_bytes(&data);
+    let errmodel = Transducer::from_bytes(&data);
+
+    let speller = Speller::new(acceptor, errmodel);
+    println!("{:?}", speller.suggest("sami"));
+}

--- a/src/speller/mod.rs
+++ b/src/speller/mod.rs
@@ -13,7 +13,7 @@ use types::{SymbolNumber, Weight, FlagDiacriticOperation};
 
 type OperationMap = BTreeMap<SymbolNumber, FlagDiacriticOperation>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Speller<'a> {
     mutator: Transducer<'a>,
     lexicon: Transducer<'a>,

--- a/src/speller/mod.rs
+++ b/src/speller/mod.rs
@@ -21,14 +21,14 @@ pub struct Speller<'a> {
     alphabet_translator: Vec<SymbolNumber>
 }
 
-struct SpellerWorker<'a> {
-    speller: &'a Speller<'a>,
+struct SpellerWorker<'a, 'b> where 'a: 'b {
+    speller: &'b Speller<'a>,
     input: Vec<SymbolNumber>,
     nodes: RefCell<Vec<TreeNode>>
 }
 
-impl<'a> SpellerWorker<'a> {
-    fn new(speller: &'a Speller<'a>) -> SpellerWorker<'a> {
+impl<'a, 'b> SpellerWorker<'a, 'b> where 'a: 'b {
+    fn new(speller: &'b Speller<'a>) -> SpellerWorker<'a, 'b> {
         SpellerWorker {
             speller: speller,
             input: vec![],
@@ -36,16 +36,16 @@ impl<'a> SpellerWorker<'a> {
         }
     }
 
-    fn lexicon_epsilons(&self, next_node: &TreeNode) {
-        let lexicon = self.speller.lexicon();
+    fn lexicon_epsilons(&'b self, next_node: &TreeNode) {
+        let lexicon: &'b Transducer<'a> = &self.speller.lexicon;
         let operations = self.speller.operations();
-        
+
         if !lexicon.has_epsilons_or_flags(next_node.lexicon_state + 1) {
             return
         }
 
         let mut next = lexicon.next(next_node.lexicon_state, 0).unwrap();
-        
+
         while let Some(transition) = lexicon.take_epsilons_and_flags(next) {
             // TODO: re-add weight limit checks
             if let Some(sym) = lexicon.transition_table().input_symbol(next) {
@@ -72,7 +72,7 @@ impl<'a> SpellerWorker<'a> {
         let mutator = self.speller.mutator();
         let lexicon = self.speller.lexicon();
         let alphabet_translator = self.speller.alphabet_translator();
-        
+
         if !mutator.has_transitions(next_node.mutator_state + 1, Some(0)) {
             return
         }
@@ -97,7 +97,7 @@ impl<'a> SpellerWorker<'a> {
                         // this input was not originally in the alphabet, so unknown or identity
                         // may apply
                         if lexicon.has_transitions(next_node.lexicon_state + 1, lexicon.alphabet().unknown()) {
-                            self.queue_lexicon_arcs(&next_node, lexicon.alphabet().unknown().unwrap(), 
+                            self.queue_lexicon_arcs(&next_node, lexicon.alphabet().unknown().unwrap(),
                                     transition.target().unwrap(), transition.weight().unwrap(), 0)
                         }
 
@@ -111,7 +111,7 @@ impl<'a> SpellerWorker<'a> {
                     continue;
                 }
 
-                self.queue_lexicon_arcs(&next_node, trans_sym, 
+                self.queue_lexicon_arcs(&next_node, trans_sym,
                         transition.target().unwrap(), transition.weight().unwrap(), 0);
                 next_m += 1;
             }
@@ -121,9 +121,9 @@ impl<'a> SpellerWorker<'a> {
     pub fn queue_lexicon_arcs(&self, next_node: &TreeNode, input_sym: SymbolNumber, mutator_state: u32, mutator_weight: Weight, input_increment: i16) {
         let lexicon = self.speller.lexicon();
         let alphabet_translator = self.speller.alphabet_translator();
-        
+
         let mut next = lexicon.next(next_node.lexicon_state, input_sym).unwrap();
-        
+
         while let Some(noneps_trans) = lexicon.take_non_epsilons(next, input_sym) {
             if let Some(mut sym) = noneps_trans.symbol() {
                 // TODO: wtf?
@@ -135,14 +135,14 @@ impl<'a> SpellerWorker<'a> {
                 // TODO: handle Correct mode
                 let mut nodes = self.nodes.borrow_mut();
                 nodes.push(next_node.update(
-                    sym, 
-                    Some(next_node.input_state + input_increment as u32), 
+                    sym,
+                    Some(next_node.input_state + input_increment as u32),
                     mutator_state,
                     noneps_trans.target().unwrap(),
                     noneps_trans.weight().unwrap()))
             }
 
-            next += 1 
+            next += 1
         }
     }
 
@@ -184,12 +184,12 @@ impl<'a> SpellerWorker<'a> {
                     continue;
                 }
 
-                self.queue_lexicon_arcs(&next_node, trans_sym, 
+                self.queue_lexicon_arcs(&next_node, trans_sym,
                         transition.target().unwrap(), transition.weight().unwrap(), 1);
                 next_m += 1;
             }
-            
-            
+
+
             // TODO: weight limit
 
         }
@@ -222,12 +222,12 @@ impl<'a> SpellerWorker<'a> {
     }
 }
 
-impl<'a> Speller<'a> {
+impl<'a, 'b> Speller<'a> where 'a: 'b {
     pub fn new(mutator: Transducer<'a>, mut lexicon: Transducer<'a>) -> Speller<'a> {
         // TODO: review why this i16 -> u16 is happening
         let size = lexicon.alphabet().state_size() as i16;
         let alphabet_translator = lexicon.mut_alphabet().create_translator_from(&mutator);
-        
+
         Speller {
             mutator: mutator,
             lexicon: lexicon,
@@ -236,11 +236,11 @@ impl<'a> Speller<'a> {
         }
     }
 
-    pub fn mutator(&'a self) -> &Transducer {
+    pub fn mutator(&'b self) -> &'b Transducer<'a> {
         &self.mutator
     }
 
-    pub fn lexicon(&'a self) -> &Transducer {
+    pub fn lexicon(&'b self) -> &'b Transducer<'a> {
         &self.lexicon
     }
 
@@ -259,7 +259,7 @@ impl<'a> Speller<'a> {
     }
 
     // orig: init_input
-    fn to_input_vec(&'a self, word: &str) -> Vec<SymbolNumber> {
+    fn to_input_vec(&'b self, word: &str) -> Vec<SymbolNumber> {
         // TODO: refactor for when mutator is optional
         let key_table = self.mutator().alphabet().key_table();
 
@@ -273,20 +273,20 @@ impl<'a> Speller<'a> {
         String::from("Hello")
     }
 
-    // Known as Speller::correct in C++    
-    pub fn suggest(&'a self, word: &str) -> Vec<String> {
+    // Known as Speller::correct in C++
+    pub fn suggest(&'b self, word: &str) -> Vec<String> {
         let lexicon = self.lexicon();
         let mutator = self.mutator();
 
         let mut worker = SpellerWorker::new(&self);
-        
+
         let start_node = TreeNode::empty(vec![self.state_size() as i16, 0]);
         let mut nodes = worker.nodes.borrow_mut();
         nodes.push(start_node);
 
         let mut corrections = BTreeMap::<String, Weight>::new();
         let mut input = self.to_input_vec(word);
-        
+
         while nodes.len() > 0 {
             let next_node = nodes.pop().unwrap();
 
@@ -300,15 +300,15 @@ impl<'a> Speller<'a> {
 
             let m_final = self.mutator().is_final(next_node.mutator_state);
             let l_final = self.lexicon().is_final(next_node.lexicon_state);
-            
+
             if !(m_final && l_final) {
                 continue;
             }
 
-            let weight = next_node.weight + 
-                self.lexicon().final_weight(next_node.lexicon_state).unwrap() + 
+            let weight = next_node.weight +
+                self.lexicon().final_weight(next_node.lexicon_state).unwrap() +
                 self.mutator().final_weight(next_node.mutator_state).unwrap();
-            
+
             // if weight > limit { }
             let key_table = self.lexicon().alphabet().key_table();
             let string: String = next_node.string.iter().map(|&s| key_table[s as usize].to_string()).collect();
@@ -324,7 +324,7 @@ impl<'a> Speller<'a> {
             .into_iter()
             .map(|x| StringWeightPair(x.0, x.1))
             .collect();
-        
+
         c.sort();
 
         c.into_iter().map(|x| x.0).collect()

--- a/src/transducer/alphabet.rs
+++ b/src/transducer/alphabet.rs
@@ -4,7 +4,7 @@ use super::Transducer;
 
 type OperationsMap = BTreeMap<SymbolNumber, FlagDiacriticOperation>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransducerAlphabet {
     key_table: Vec<String>,
     initial_symbol_count: SymbolNumber,

--- a/src/transducer/header.rs
+++ b/src/transducer/header.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 
 use types::{SymbolNumber, TransitionTableIndex, HeaderFlag};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransducerHeader {
     symbols: SymbolNumber,
     input_symbols: SymbolNumber,

--- a/src/transducer/index_table.rs
+++ b/src/transducer/index_table.rs
@@ -6,7 +6,7 @@ use types::{TransitionTableIndex, SymbolNumber, Weight};
 use constants::TRANS_INDEX_SIZE;
 use std::cell::{RefCell, RefMut};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IndexTable<'a> {
     size: TransitionTableIndex,
     cursor: RefCell<Cursor<&'a [u8]>>
@@ -50,7 +50,7 @@ impl<'a> IndexTable<'a> {
 
         // BUG: see below
         // TODO: this is the same as target, and therefore probably a bug
-        
+
         let index: u64 = (TRANS_INDEX_SIZE * (i as usize) + mem::size_of::<SymbolNumber>()) as u64;
         let mut cursor = self.cursor.borrow_mut();
         cursor.set_position(index);

--- a/src/transducer/mod.rs
+++ b/src/transducer/mod.rs
@@ -15,7 +15,7 @@ use self::index_table::IndexTable;
 use self::transition_table::TransitionTable;
 use self::symbol_transition::SymbolTransition;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Transducer<'a> {
     buf: &'a [u8],
     header: TransducerHeader,

--- a/src/transducer/mod.rs
+++ b/src/transducer/mod.rs
@@ -24,14 +24,14 @@ pub struct Transducer<'a> {
     transition_table: TransitionTable<'a>
 }
 
-impl<'a> Transducer<'a> {
+impl<'a, 'b> Transducer<'a> where 'a: 'b {
     pub fn from_bytes(buf: &[u8]) -> Transducer {
         let header = TransducerHeader::new(&buf);
         let alphabet_offset = header.alphabet_offset();
         let alphabet = TransducerAlphabet::new(&buf[alphabet_offset..buf.len()], header.symbol_count());
 
         let index_table_offset = alphabet_offset + alphabet.length();
-        
+
         let index_table_end = index_table_offset + TRANS_INDEX_SIZE * header.index_table_size();
         let index_table = IndexTable::new(&buf[index_table_offset..index_table_end], header.index_table_size() as u32);
 
@@ -50,11 +50,11 @@ impl<'a> Transducer<'a> {
     // Orig: get_key_table on alphabet ref
     // TODO: get_encoder
 
-    pub fn index_table(&self) -> &'a IndexTable {
+    pub fn index_table(&'b self) -> &'b IndexTable<'a> {
         &self.index_table
     }
 
-    pub fn transition_table(&self) -> &'a TransitionTable {
+    pub fn transition_table(&self) -> &TransitionTable<'a> {
         &self.transition_table
     }
 
@@ -89,7 +89,7 @@ impl<'a> Transducer<'a> {
         } else {
             match self.index_table.input_symbol(i + sym as u32) {
                 Some(res) => sym == res,
-                None => false   
+                None => false
             }
         }
     }
@@ -137,8 +137,8 @@ impl<'a> Transducer<'a> {
             if res != 0 {
                return None;
             }
-        } 
-        
+        }
+
         Some(self.transition_table.symbol_transition(i))
     }
 
@@ -147,18 +147,18 @@ impl<'a> Transducer<'a> {
             if res != 0 && !self.alphabet.is_flag(res) {
                return None;
             }
-        } 
-        
+        }
+
         Some(self.transition_table.symbol_transition(i))
     }
-    
+
     pub fn take_non_epsilons(&self, i: TransitionTableIndex, symbol: SymbolNumber) -> Option<SymbolTransition> {
         if let Some(res) = self.transition_table.input_symbol(i) {
             if res != symbol {
                return None;
             }
-        } 
-        
+        }
+
         Some(self.transition_table.symbol_transition(i))
     }
 
@@ -186,5 +186,5 @@ impl<'a> Transducer<'a> {
 
     pub fn is_weighted(&self) -> bool {
         self.header.has_flag(HeaderFlag::Weighted)
-    } 
+    }
 }

--- a/src/transducer/transition_table.rs
+++ b/src/transducer/transition_table.rs
@@ -8,7 +8,7 @@ use constants::{TRANS_SIZE, TRANS_INDEX_SIZE};
 
 use transducer::symbol_transition::SymbolTransition;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TransitionTable<'a> {
     size: TransitionTableIndex,
     cursor: RefCell<Cursor<&'a [u8]>>
@@ -51,7 +51,7 @@ impl<'a> TransitionTable<'a> {
         if i >= self.size {
             return None;
         }
-        
+
         let index: u64 = ((TRANS_SIZE * i as usize) + (2 * mem::size_of::<SymbolNumber>())) as u64;
         let mut cursor = self.cursor.borrow_mut();
         cursor.set_position(index);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum FlagDiacriticOperator {
     PositiveSet, NegativeSet, Require, Disallow, Clear, Unification
 }
@@ -32,7 +32,7 @@ pub enum HeaderFlag {
     HasUnweightedInputEpsilonCycles
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FlagDiacriticOperation {
     pub operation: FlagDiacriticOperator,
     pub feature: SymbolNumber,


### PR DESCRIPTION
So, before we had `'a` for a whole bunch of stuff, esp. in things like
`&'a Speller<'a>`. That lead to some weird borrowck errors. While I'm
sure there are more clever solutions to this, I just split those
lifetimes into two: One to indicate the scope of the reference, and one
to show the actual life time of the data.

In this relation, the data always needs to outlive the references to it,
so: `'a: 'b`.